### PR TITLE
Fix next dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ appropriately please let me know).
 var CronJob = require('cron').CronJob;
 var job = new CronJob(
 	'* * * * * *',
-	function() {
+	function () {
 		console.log('You will see this message every second');
 	},
 	null,
@@ -162,6 +162,7 @@ Parameter Based
   - `stop` - Stops your job.
   - `setTime` - Stops and changes the time for the `CronJob`. Param must be a `CronTime`.
   - `lastDate` - Tells you the last execution date.
+  - `nextDate` - Provides the next date that will trigger an `onTick`.
   - `nextDates` - Provides an array of the next set of dates that will trigger an `onTick`.
   - `fireOnTick` - Allows you to override the `onTick` calling behavior. This
     matters so only do this if you have a really good reason to do so.

--- a/lib/job.js
+++ b/lib/job.js
@@ -105,7 +105,7 @@ function CronJob(CronTime, spawn) {
 	CJ.prototype.fireOnTick = fireOnTick;
 
 	CJ.prototype.nextDates = function (i) {
-		return this.cronTime.sendAt(i);
+		return this.cronTime.sendAt(i || 0);
 	};
 
 	var start = function () {

--- a/tests/cron.test.js
+++ b/tests/cron.test.js
@@ -891,6 +891,16 @@ describe('cron', () => {
 		clock.restore();
 	});
 
+	it('Should give an empty array', () => {
+		const callback = jest.fn();
+		const clock = sinon.useFakeTimers();
+		const job = new cron.CronJob('* * * * * *', callback);
+
+		expect(job.nextDates()).toHaveLength(0);
+
+		clock.restore();
+	});
+
 	it('should automatically setup a new timeout if we roll past the max timeout delay', () => {
 		const callback = jest.fn();
 		const clock = sinon.useFakeTimers();


### PR DESCRIPTION
## Proposed changes

- Make sure that `nextDates` return an array(as described in the README.md) even if it's called without an argument(in this case an empty array)
- Add `nextDate` description in the README.md

## Current behaviour

`nextDates` return a moment object, if it's called without an argument

## Details

- This change could break someone's code!!
- If this PR is not accepted, I will make another PR just to update the description of the behaviour of `nextDates` function in the READM.md
